### PR TITLE
ISSUE-9: Add a 10-sec time-limit for the buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kinesis-Sumologic Connector
 
-The **Kinesis-Sumologic Connector** is a Java connector that acts as a pipeline between an [Amazon Kinesis] stream and a [Sumologic] Collection. Data gets fetched from the Kinesis Stream, transformed into a POJO and then sent to the Sumologic Collection as JSON.
+The **Kinesis-Sumologic Connector** is a Java connector that acts as a pipeline between an [Amazon Kinesis] stream and a [Sumologic] Collection. Data gets fetched from the Kinesis Stream, transformed into a POJO and then sent to the Sumologic Collection as JSON. End-user setup instructions can be found in [here](https://support.sumologic.com/hc/en-us/articles/209667668-Sumo-Logic-App-for-Amazon-VPC-Flow-Logs-using-Kinesis).
 
 ## Requirements
 

--- a/SumologicConnector.properties
+++ b/SumologicConnector.properties
@@ -16,6 +16,7 @@ regionName = us-east-1
 retryLimit = 3
 backoffInterval = 50000
 bufferRecordCountLimit = 100
+bufferMillisecondsLimit = 10000
 
 # Amazon Kinesis parameters for KinesisConnector
 

--- a/configuration/cloudformation/cwl_kinesis.template
+++ b/configuration/cloudformation/cwl_kinesis.template
@@ -432,6 +432,9 @@
 				 "# metrics for connector will be created in this region. All resources in outgoing destination will not be affected by this region name.\n",
 				 "regionName = ",{"Ref": "AWS::Region"},"\n",
 				 "retryLimit = 3\n",
+				 "backoffInterval = 50000\n",
+				 "bufferRecordCountLimit = 100\n",
+				 "bufferMillisecondsLimit = 10000\n",
 
 				 "# Amazon Kinesis parameters for KinesisConnector\n\n",
 

--- a/configuration/cloudformation/cwl_kinesis_custom_vpc.template
+++ b/configuration/cloudformation/cwl_kinesis_custom_vpc.template
@@ -298,6 +298,9 @@
 				 "# metrics for connector will be created in this region. All resources in outgoing destination will not be affected by this region name.\n",
 				 "regionName = ",{"Ref": "AWS::Region"},"\n",
 				 "retryLimit = 3\n",
+				 "backoffInterval = 50000\n",
+				 "bufferRecordCountLimit = 100\n",
+				 "bufferMillisecondsLimit = 10000\n",
 
 				 "# Amazon Kinesis parameters for KinesisConnector\n\n",
 


### PR DESCRIPTION
Currently the buffer doesn't push until there are 100 raw Kinesis records, which sometimes translates to hours of delay. 
