### PR TITLE
Allow specifying .properties files as arguments to handle multiple streams

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -118,7 +118,9 @@
                classpathref="sumologic.classpath"
                includes="com/sumologic/kinesis/*.java, com/sumologic/kinesis/utils/*.java,
                          com/sumologic/client/*.java, com/sumologic/client/implementations/*.java"/>
-        <java classname="com.sumologic.client.SumologicExecutor" classpathref="sumologic.classpath" fork="true" />
+		<java classname="com.sumologic.client.SumologicExecutor" classpathref="sumologic.classpath" fork="true">
+			<arg line="${args}"/>
+		</java>
 	</target>
 
     <target name="run">

--- a/src/main/java/com/sumologic/client/SumologicExecutor.java
+++ b/src/main/java/com/sumologic/client/SumologicExecutor.java
@@ -38,7 +38,6 @@ public class SumologicExecutor extends
 		ArrayList<Thread> executorThreads = new ArrayList<Thread>();
 
 		for (String arg : args) {
-			System.out.println("arg:" + arg);
 			if (arg.endsWith(".properties")) {
 				configFiles.add(arg);
 			}

--- a/src/main/java/com/sumologic/client/SumologicExecutor.java
+++ b/src/main/java/com/sumologic/client/SumologicExecutor.java
@@ -1,35 +1,67 @@
 package com.sumologic.client;
 
+import java.util.ArrayList;
+
 import com.sumologic.kinesis.KinesisConnectorRecordProcessorFactory;
 import com.sumologic.kinesis.KinesisConnectorExecutor;
 import com.sumologic.client.SumologicMessageModelPipeline;
 import com.sumologic.client.model.SimpleKinesisMessageModel;
 
-public class SumologicExecutor extends KinesisConnectorExecutor<SimpleKinesisMessageModel, String> {
-    private static String configFile = "SumologicConnector.properties";
+public class SumologicExecutor extends
+		KinesisConnectorExecutor<SimpleKinesisMessageModel, String> {
+	private static String defaultConfigFile = "SumologicConnector.properties";
 
-    /**
-    * SumologicExecutor constructor.
-    * @param configFile Properties for the connector
-    */
-    public SumologicExecutor(String configFile) {
-        super(configFile);
-    }
+	/**
+	 * SumologicExecutor constructor.
+	 * 
+	 * @param configFile
+	 *            Properties for the connector
+	 */
+	public SumologicExecutor(String configFile) {
+		super(configFile);
+	}
 
-    @Override
-    public KinesisConnectorRecordProcessorFactory<SimpleKinesisMessageModel, String>
-            getKinesisConnectorRecordProcessorFactory() {
-        return new KinesisConnectorRecordProcessorFactory<SimpleKinesisMessageModel, String>
-                    (new SumologicMessageModelPipeline(),config);
-    }
+	@Override
+	public KinesisConnectorRecordProcessorFactory<SimpleKinesisMessageModel, String> getKinesisConnectorRecordProcessorFactory() {
+		return new KinesisConnectorRecordProcessorFactory<SimpleKinesisMessageModel, String>(
+				new SumologicMessageModelPipeline(), config);
+	}
 
-    /**
-     * Main method starts and runs the SumologicExecutor.
-     * @param args
-     */
-    public static void main(String[] args) {  
-        KinesisConnectorExecutor<SimpleKinesisMessageModel, String> sumologicExecutor =
-                new SumologicExecutor(configFile);
-        sumologicExecutor.run();
-    }
+	/**
+	 * Main method starts and runs the SumologicExecutor.
+	 * 
+	 * @param args
+	 * @throws InterruptedException 
+	 */
+	public static void main(String[] args) throws InterruptedException {
+		ArrayList<String> configFiles = new ArrayList<String>();
+		ArrayList<Thread> executorThreads = new ArrayList<Thread>();
+
+		for (String arg : args) {
+			System.out.println("arg:" + arg);
+			if (arg.endsWith(".properties")) {
+				configFiles.add(arg);
+			}
+		}
+
+		// if none of the arguments contained a config file, try the default
+		// file name
+		if (configFiles.size() == 0) {
+			configFiles.add(defaultConfigFile);
+		}
+
+		for (String configFile : configFiles) {
+
+			KinesisConnectorExecutor<SimpleKinesisMessageModel, String> sumologicExecutor = new SumologicExecutor(
+					configFile);
+
+			Thread executorThread = new Thread(sumologicExecutor);
+			executorThreads.add(executorThread);
+			executorThread.start();
+		}
+
+		for(Thread executorThread : executorThreads){
+			executorThread.join();
+		}
+	}
 }

--- a/src/main/java/com/sumologic/kinesis/KinesisConnectorExecutor.java
+++ b/src/main/java/com/sumologic/kinesis/KinesisConnectorExecutor.java
@@ -58,6 +58,8 @@ public abstract class KinesisConnectorExecutor<T, U> extends KinesisConnectorExe
             throw new IllegalStateException(msg, e);
         }
         this.config = new KinesisConnectorForSumologicConfiguration(properties, getAWSCredentialsProvider());
+        
+        LOG.info("Using " + configFile);
 
         // Send sample data to AWS Kinesis if specified in the properties file
         setupInputStream();


### PR DESCRIPTION
The connector currently only handles one kinesis stream, and collector URL. We have multiple kinesis streams that we want to forward to sumologic.
This PR adds capability of specifying multiple .properties files, to allow specifying multiple stream / sumo url pairs.

The implementation was easy, as SumologicExecutor already was a Runnable, taking a configFile as argument. 
You can now specify multiple config files, lanching multiple SumologicExecutors like so:

```
ant run -Dargs='app1.properties app2.properties'
```

The SumologicConnector.properties file is still required to be present in the working directory, as it's hardcoded into the application as the file AWS credentials are read from.

This change is backwards compatible, if no .properties files are passed as arguments, SumologicConnector.properties is assumed as the only SumologicExecutor
